### PR TITLE
Reverted timingApi version

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -1,8 +1,5 @@
 Release Notes for the evrClient and event package
 --------------------------------------------------
-R1.5.5  2025-06-12 Jane Liu (JLIU)
-		* Updated timingApi to R0.11
-
 R1.5.4  2025-01-29 Jeremy Lorelli (LORELLI)
         * Add support for rocky 9 and cleanup CONFIG_SITE files
         * Upgrade evrmaDriver, evrma to R1.0.12

--- a/configure/RELEASE.local
+++ b/configure/RELEASE.local
@@ -20,7 +20,7 @@
 # could match a directory name.
 # ==========================================================
 MISCUTILS_MODULE_VERSION    = R2.2.5
-TIMINGAPI_MODULE_VERSION    = R0.11
+TIMINGAPI_MODULE_VERSION    = R0.9
 BSACORE_MODULE_VERSION      = R1.5.6
 
 # ==========================================================
@@ -32,7 +32,6 @@ BSACORE_MODULE_VERSION      = R1.5.6
 MISCUTILS	= $(EPICS_MODULES)/miscUtils/$(MISCUTILS_MODULE_VERSION)
 TIMINGAPI   = $(EPICS_MODULES)/timingApi/$(TIMINGAPI_MODULE_VERSION)
 BSACORE     = $(EPICS_MODULES)/BsaCore/$(BSACORE_MODULE_VERSION)
-
 
 # Set EPICS_BASE last so it appears last in the DB, DBD, INCLUDE, and LIB search paths
 EPICS_BASE  = $(EPICS_SITE_TOP)/base/$(BASE_MODULE_VERSION)


### PR DESCRIPTION
Reverted timingApi version to R0.9, so BsaCore's timingApi doesn't need to be changed.